### PR TITLE
replaced run-shell-command

### DIFF
--- a/scripts/visitplot.lisp
+++ b/scripts/visitplot.lisp
@@ -480,7 +480,7 @@
          (cmd (format nil "montage ~A/*.ppm -geometry +~D+~D ~A/montage.png"
                       dirname dim dim dirname)))
     (colormap->canvases colormap dirname)
-    (asdf:run-shell-command cmd)))
+    (uiop:run-program cmd)))
 
 
 ;; NB: to reduce memory footprint, do a binary merge superimpose on
@@ -502,7 +502,7 @@
                                                          ppm-path)
                                ".png")))
     (format t "png-path: ~A~%" png-path)
-    (asdf:run-shell-command (format nil "convert -scale 200% ~A ~A" ppm-path png-path))))
+    (uiop:run-program (format nil "convert -scale 200% ~A ~A" ppm-path png-path))))
 
 
 (defun heatmap->canvas (heatmap-path &key ppm-path elf-path)


### PR DESCRIPTION
I replaced from asdf:run-shell-command to uiop:run-program.
Because, this kind of warning comes out.

```common-lisp
WARNING:
   DEPRECATED-FUNCTION-STYLE-WARNING: Using deprecated function ASDF/BACKWARD-INTERFACE:RUN-SHELL-COMMAND -- please update your code to use a newer API.
The docstring for this function says:
PLEASE DO NOT USE. This function is not just DEPRECATED, but also dysfunctional.
Please use UIOP:RUN-PROGRAM instead.
```